### PR TITLE
fix(android): capacitor beta 25 updates

### DIFF
--- a/android/capacitor-downloader/build.gradle
+++ b/android/capacitor-downloader/build.gradle
@@ -11,9 +11,9 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 25
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
@@ -42,7 +42,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'ionic-team:capacitor-android:1+'
+    implementation project(':capacitor-android')
      implementation ('co.fitcom:fancydownloader:0.6.3'){
         exclude group: "com.android.support"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "capacitor-downloader",
-  "version": "1.1.4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@capacitor/core": {
-      "version": "1.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.0.0-beta.13.tgz",
-      "integrity": "sha512-D602SsYCVaZT095jnaR3STWzjeTnStzdpkbeYQpQZMnmDSN6pzA4FnnGbi6cmzbIARxGdhPOm4CveX9hmP65DA==",
+      "version": "1.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.0.0-beta.25.tgz",
+      "integrity": "sha512-DjVY0J0q3wUAOCVd5n2Dx6eSwc5AiRZcjL0qvi/7J34WQ2q++BKEp3nA0jNfdITnh9jbDd4LeBRDzIoqb6djZQ==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-downloader",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Updates the `compileSDKVersion` to 28 and moves the minimum API version to 25.

Additionally updates the usage of referencing capacitor-android, which resolves errors you may experience when assembling a release.

i.e. (example errors):
```
14:13:21 /var/jenkins_home/workspace/demo_app/node_modules/capacitor-downloader/android/capacitor-downloader/build/intermediates/res/merged/release/values-v28/values-v28.xml:11: AAPT: error: resource android:attr/dialogCornerRadius not found.
14:13:21     
```