### PR TITLE
change minSdkVersion to 21

### DIFF
--- a/android/capacitor-downloader/build.gradle
+++ b/android/capacitor-downloader/build.gradle
@@ -13,8 +13,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 25
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
I've tested and works fine on my Android 5 devices, so I think it was changed to 25 by mistake
Also changed `targetSdkVersion` to 28 to match Capacitor's `targetSdkVersion` and the `compileSdkVersion`
Closes #9