### PR TITLE
use file url for the DownloadRequest

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -76,8 +76,8 @@ public class DownloaderPlugin: CAPPlugin {
         
         
         let destination: DownloadRequest.DownloadFileDestination = { _, _ in
-            let fileURL = URL(string: fullPath)
-            return (fileURL!, [.removePreviousFile, .createIntermediateDirectories])
+            let fileURL = URL(fileURLWithPath: fullPath)
+            return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
         }
         
         let id = self.generateId()


### PR DESCRIPTION
`URL(string: fullPath)` produces an url without scheme, which is causing the plugin to fail.

By using `URL(fileURLWithPath: fullPath)` you get a filesystem url staring by file:/// and fixes the problem. 

closes #10 
closes #11